### PR TITLE
Add basic Tkinter GUI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ You can find detailed commands usage [here](doc/COMMANDS.md).
 
     * As an interactive prompt `python3 main.py <target username>`
     * Or execute your command straight away `python3 main.py <target username> --command <command>`
+
+## GUI mode
+
+Run `python3 main.py --gui` to start a simple graphical interface. The GUI lets you
+enter your Instagram username, password and target profile, toggle the `FILE` and
+`JSON` options and choose a command to run. Results are displayed in the window.
     
 ### Use Osintgram v2 (beta)
 You can use Osintgram2 beta just switching to `v2` [branch](https://github.com/Datalux/Osintgram/tree/v2).

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,95 @@
+import io
+import sys
+import tkinter as tk
+from tkinter import ttk, scrolledtext
+
+from src.Osintgram import Osintgram
+from src import config
+
+
+def run_gui():
+    root = tk.Tk()
+    root.title("Osintgram GUI")
+
+    tk.Label(root, text="Username:").grid(row=0, column=0, sticky="e")
+    username_var = tk.StringVar()
+    tk.Entry(root, textvariable=username_var).grid(row=0, column=1, padx=5, pady=2)
+
+    tk.Label(root, text="Password:").grid(row=1, column=0, sticky="e")
+    password_var = tk.StringVar()
+    tk.Entry(root, textvariable=password_var, show="*").grid(row=1, column=1, padx=5, pady=2)
+
+    tk.Label(root, text="Target:").grid(row=2, column=0, sticky="e")
+    target_var = tk.StringVar()
+    tk.Entry(root, textvariable=target_var).grid(row=2, column=1, padx=5, pady=2)
+
+    file_var = tk.BooleanVar()
+    tk.Checkbutton(root, text="FILE", variable=file_var).grid(row=3, column=0, sticky="w", padx=5)
+    json_var = tk.BooleanVar()
+    tk.Checkbutton(root, text="JSON", variable=json_var).grid(row=3, column=1, sticky="w", padx=5)
+
+    tk.Label(root, text="Command:").grid(row=4, column=0, sticky="e")
+    command_var = tk.StringVar()
+    command_box = ttk.Combobox(root, textvariable=command_var, width=25)
+    command_box.grid(row=4, column=1, padx=5, pady=2)
+
+    output_area = scrolledtext.ScrolledText(root, width=60, height=20)
+    output_area.grid(row=6, column=0, columnspan=2, padx=5, pady=5)
+
+    def run_command():
+        user = username_var.get()
+        pwd = password_var.get()
+        tgt = target_var.get()
+        cmd = command_var.get()
+        config.config["Credentials"] = {"username": user, "password": pwd}
+        api = Osintgram(tgt, file_var.get(), json_var.get(), cmd, None, False)
+        commands = {
+            'addrs':            api.get_addrs,
+            'cache':            api.clear_cache,
+            'captions':         api.get_captions,
+            'commentdata':      api.get_comment_data,
+            'comments':         api.get_total_comments,
+            'followers':        api.get_followers,
+            'followings':       api.get_followings,
+            'fwersemail':       api.get_fwersemail,
+            'fwingsemail':      api.get_fwingsemail,
+            'fwersnumber':      api.get_fwersnumber,
+            'fwingsnumber':     api.get_fwingsnumber,
+            'hashtags':         api.get_hashtags,
+            'info':             api.get_user_info,
+            'likes':            api.get_total_likes,
+            'mediatype':        api.get_media_type,
+            'photodes':         api.get_photo_description,
+            'photos':           api.get_user_photo,
+            'propic':           api.get_user_propic,
+            'stories':          api.get_user_stories,
+            'tagged':           api.get_people_tagged_by_user,
+            'target':           api.change_target,
+            'wcommented':       api.get_people_who_commented,
+            'wtagged':          api.get_people_who_tagged,
+        }
+        command_box['values'] = list(commands.keys())
+        func = commands.get(cmd)
+        if func:
+            buffer = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = buffer
+            try:
+                res = func()
+            finally:
+                sys.stdout = old_stdout
+            text = buffer.getvalue()
+            if res:
+                text += str(res)
+        else:
+            text = "Unknown command"
+        output_area.delete('1.0', tk.END)
+        output_area.insert(tk.END, text)
+
+    tk.Button(root, text="Run", command=run_command).grid(row=5, column=0, columnspan=2, pady=5)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    run_gui()

--- a/main.py
+++ b/main.py
@@ -107,15 +107,24 @@ else:
 
 parser = argparse.ArgumentParser(description='Osintgram is a OSINT tool on Instagram. It offers an interactive shell '
                                              'to perform analysis on Instagram account of any users by its nickname ')
-parser.add_argument('id', type=str,  # var = id
+parser.add_argument('id', type=str, nargs='?',
                     help='username')
 parser.add_argument('-C','--cookies', help='clear\'s previous cookies', action="store_true")
 parser.add_argument('-j', '--json', help='save commands output as JSON file', action='store_true')
 parser.add_argument('-f', '--file', help='save output in a file', action='store_true')
 parser.add_argument('-c', '--command', help='run in single command mode & execute provided command', action='store')
 parser.add_argument('-o', '--output', help='where to store photos', action='store')
+parser.add_argument('-g', '--gui', help='run graphical interface', action='store_true')
 
 args = parser.parse_args()
+
+if args.gui:
+    from gui import run_gui
+    run_gui()
+    sys.exit(0)
+
+if not args.id:
+    parser.error('the following arguments are required: id')
 
 
 api = Osintgram(args.id, args.file, args.json, args.command, args.output, args.cookies)


### PR DESCRIPTION
## Summary
- add `gui.py` with a Tkinter interface
- enable `--gui` flag in main entry point
- update README with GUI instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885b650b54483288a1fed449c08ea89